### PR TITLE
Give sensible name for python argument

### DIFF
--- a/src/Python/open3d_pybind/visualization/visualizer.cpp
+++ b/src/Python/open3d_pybind/visualization/visualizer.cpp
@@ -87,7 +87,7 @@ void pybind_visualizer(py::module &m) {
             .def("reset_view_point", &visualization::Visualizer::ResetViewPoint,
                  "Function to reset view point")
             .def("update_geometry", &visualization::Visualizer::UpdateGeometry,
-                 "Function to update geometry")
+                 "Function to update geometry", "geometry"_a)
             .def("update_renderer", &visualization::Visualizer::UpdateRender,
                  "Function to inform render needed to be updated")
             .def("poll_events", &visualization::Visualizer::PollEvents,


### PR DESCRIPTION
```
TypeError: update_geometry(): incompatible function arguments. The following argument types are supported:
    1. (self: open3d.open3d.visualization.Visualizer, arg0: open3d.open3d.geometry.Geometry) -> bool
```
Just felt if `arg0` could be replaced by an appropriate name for python.